### PR TITLE
feat: Implement Admin Diagnostics System within Settings Page

### DIFF
--- a/backend/src/handlers/diagnostics/__init__.py
+++ b/backend/src/handlers/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+# This file makes 'diagnostics' a Python package.

--- a/backend/src/handlers/diagnostics/check_dynamodb.py
+++ b/backend/src/handlers/diagnostics/check_dynamodb.py
@@ -1,0 +1,41 @@
+import json
+import boto3
+
+def lambda_handler(event, context):
+    """
+    Lambda handler to check DynamoDB connectivity by listing tables.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"  # CORS header
+    }
+
+    try:
+        dynamodb = boto3.client('dynamodb')
+        response = dynamodb.list_tables()  # Example operation
+        
+        table_count = len(response.get('TableNames', []))
+        
+        return {
+            "statusCode": 200,
+            "headers": headers,
+            "body": json.dumps({
+                "success": True,
+                "message": f"DynamoDB connectivity test successful. Found {table_count} tables."
+            })
+        }
+    except Exception as e:
+        print(f"Error connecting to DynamoDB: {str(e)}")
+        return {
+            "statusCode": 500,
+            "headers": headers,
+            "body": json.dumps({
+                "success": False,
+                "message": f"Error connecting to DynamoDB: {str(e)}"
+            })
+        }
+
+if __name__ == '__main__':
+    # For local testing (optional)
+    # Ensure AWS credentials and region are configured locally for this to work
+    print(lambda_handler(None, None))

--- a/backend/src/handlers/diagnostics/check_s3.py
+++ b/backend/src/handlers/diagnostics/check_s3.py
@@ -1,0 +1,41 @@
+import json
+import boto3
+
+def lambda_handler(event, context):
+    """
+    Lambda handler to check S3 connectivity by listing buckets.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"  # CORS header
+    }
+
+    try:
+        s3 = boto3.client('s3')
+        response = s3.list_buckets()  # Example operation
+        
+        bucket_count = len(response.get('Buckets', []))
+        
+        return {
+            "statusCode": 200,
+            "headers": headers,
+            "body": json.dumps({
+                "success": True,
+                "message": f"S3 connectivity test successful. Found {bucket_count} buckets."
+            })
+        }
+    except Exception as e:
+        print(f"Error connecting to S3: {str(e)}")
+        return {
+            "statusCode": 500,
+            "headers": headers,
+            "body": json.dumps({
+                "success": False,
+                "message": f"Error connecting to S3: {str(e)}"
+            })
+        }
+
+if __name__ == '__main__':
+    # For local testing (optional)
+    # Ensure AWS credentials and region are configured locally for this to work
+    print(lambda_handler(None, None))

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -749,6 +749,76 @@ Resources:
             Auth:
               Authorizer: NONE
 
+  DiagnosticsOptions:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/handlers/cors/
+      Handler: cors_options.lambda_handler
+      Events:
+        S3DiagnosticsOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ClinicAPI
+            Path: /diagnostics/s3
+            Method: options
+            Auth:
+              Authorizer: NONE
+        DynamoDBDiagnosticsOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ClinicAPI
+            Path: /diagnostics/dynamodb
+            Method: options
+            Auth:
+              Authorizer: NONE
+
+  # Lambda Functions for Diagnostics
+  CheckS3ConnectivityFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/handlers/diagnostics/
+      Handler: check_s3.lambda_handler
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - s3:ListAllMyBuckets
+              Resource: "*"
+      Layers:
+        - !Ref UtilsLayer
+      Events:
+        CheckS3:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ClinicAPI
+            Path: /diagnostics/s3
+            Method: get
+            Auth:
+              Authorizer: CognitoAuthorizer
+
+  CheckDynamoDBConnectivityFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/handlers/diagnostics/
+      Handler: check_dynamodb.lambda_handler
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:ListTables
+              Resource: "*"
+      Layers:
+        - !Ref UtilsLayer
+      Events:
+        CheckDynamoDB:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ClinicAPI
+            Path: /diagnostics/dynamodb
+            Method: get
+            Auth:
+              Authorizer: CognitoAuthorizer
+
   # Lambda Functions for Appointments
   GetAppointmentsFunction:
     Type: AWS::Serverless::Function

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,19 +1,19 @@
-import { useEffect } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+// This file can be further simplified or removed if it's no longer the main entry point
+// for routing after changes. For now, just removing the specified content.
 
 function App() {
-  const location = useLocation();
-  
-  useEffect(() => {
-    // Initialize your app state based on the current route
-    // This will ensure proper state initialization on direct page loads
-    console.log('App initialized at path:', location.pathname);
-    // Load necessary data based on current route
-  }, []);
-  
-  return (
-    // ...existing routes and components
-  );
+  // The useEffect and useLocation hooks were primarily for the routing setup
+  // that is now being moved. If App.js has other global responsibilities,
+  // they would remain here. Otherwise, this component might become very minimal
+  // or could be removed if routing is fully handled by router.jsx.
+
+  console.log('App component rendered, but routing is primarily handled in router.jsx');
+
+  // Return null or a minimal placeholder if this component no longer renders routes.
+  // Depending on how the rest of the application is structured,
+  // this component might not even be rendered directly by index.js if
+  // router.jsx and its BrowserRouter take precedence.
+  return null; 
 }
 
 export default App;

--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -22,6 +22,8 @@ import DoctorSchedulePage from "../pages/DoctorSchedulePage";
 import FrontdeskCheckoutPage from "../pages/FrontdeskCheckoutPage";
 import AdminReportsPage from "../pages/AdminReportsPage";
 import StyleGuidePage from "../pages/StyleGuidePage";
+import DiagnosticsPage from "../pages/DiagnosticsPage"; // Import the DiagnosticsPage component
+import AdminSettingsPage from "../pages/AdminSettingsPage"; // Import the AdminSettingsPage component
 import AppLayout from "../components/Layout/AppLayout";
 import ProtectedRoute from "./ProtectedRoute";
 
@@ -111,6 +113,24 @@ function AppRouter() {
           element={
             <ProtectedRoute allowedRoles={["admin"]}>
               <AdminReportsPage />
+            </ProtectedRoute>
+          }
+        />
+        {/* Add route for Admin Diagnostics Page */}
+        <Route
+          path="/admin/diagnostics"
+          element={
+            <ProtectedRoute allowedRoles={["admin"]}>
+              <DiagnosticsPage />
+            </ProtectedRoute>
+          }
+        />
+        {/* Add route for Admin Settings Page */}
+        <Route
+          path="/admin/settings"
+          element={
+            <ProtectedRoute allowedRoles={["admin"]}>
+              <AdminSettingsPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+const Layout = ({ children }) => {
+  return (
+    <Box>
+      {/* Placeholder for future Navbar or Sidebar */}
+      {children}
+    </Box>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/Layout/AdminSidebar.jsx
+++ b/frontend/src/components/Layout/AdminSidebar.jsx
@@ -1,12 +1,13 @@
 // src/components/Layout/AdminSidebar.jsx
 import React from 'react';
-import { List } from '@mui/material';
+import { List, Box } from '@mui/material'; // Added Box
 import HomeIcon from '@mui/icons-material/Home';
 import PeopleIcon from '@mui/icons-material/People';
 import EventIcon from '@mui/icons-material/Event';
 import PersonIcon from '@mui/icons-material/Person';
 import MedicalServicesIcon from '@mui/icons-material/MedicalServices';
 import AssessmentIcon from '@mui/icons-material/Assessment';
+import SettingsIcon from '@mui/icons-material/Settings'; // Added SettingsIcon
 import ActiveNavLink from '../ActiveNavLink';
 
 function AdminSidebar({ collapsed = false }) {
@@ -52,6 +53,13 @@ function AdminSidebar({ collapsed = false }) {
         to="/admin/reports"
         icon={<AssessmentIcon />}
         primary="Reports"
+        collapsed={collapsed}
+      />
+      <Box sx={{ flexGrow: 1 }} /> {/* Spacer to push Settings to the bottom */}
+      <ActiveNavLink
+        to="/admin/settings"
+        icon={<SettingsIcon />}
+        primary="Settings"
         collapsed={collapsed}
       />
     </List>

--- a/frontend/src/pages/AdminSettingsPage.jsx
+++ b/frontend/src/pages/AdminSettingsPage.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, Typography, Container, Paper } from '@mui/material';
+import DiagnosticsPage from './DiagnosticsPage'; // Assuming DiagnosticsPage is in the same directory
+
+function AdminSettingsPage() {
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom sx={{ mb: 3 }}>
+        Admin Settings
+      </Typography>
+
+      {/* System Diagnostics Section */}
+      <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 2 }}>
+          System Diagnostics
+        </Typography>
+        <DiagnosticsPage />
+      </Paper>
+
+      {/* Placeholder for future settings sections */}
+      {/* 
+      <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h5" component="h2" gutterBottom>
+          Other Settings Section (Future)
+        </Typography>
+        <Typography>
+          Content for other settings will go here.
+        </Typography>
+      </Paper>
+      */}
+    </Container>
+  );
+}
+
+export default AdminSettingsPage;

--- a/frontend/src/pages/DiagnosticsPage.jsx
+++ b/frontend/src/pages/DiagnosticsPage.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Card,
+  CardContent,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Chip,
+  Container,
+  Divider,
+} from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import LanguageIcon from '@mui/icons-material/Language';
+import CloudQueueIcon from '@mui/icons-material/CloudQueue';
+import FunctionsIcon from '@mui/icons-material/Functions';
+import StorageIcon from '@mui/icons-material/Storage';
+import DnsIcon from '@mui/icons-material/Dns'; // Alternative for DynamoDB: DataObjectIcon
+
+import adminService from '../services/adminService'; // Ensure this path is correct
+
+const initialServices = [
+  { id: 'site', name: 'Site Frontend', status: 'Online', details: 'Page loaded successfully.', testable: false, icon: <LanguageIcon /> },
+  { id: 'apiGateway', name: 'API Gateway', status: 'Unknown', details: '', testable: false, icon: <CloudQueueIcon /> },
+  { id: 'lambdas', name: 'Lambda Functions', status: 'Unknown', details: '', testable: false, icon: <FunctionsIcon /> },
+  { id: 's3', name: 'S3 Storage', status: 'Unknown', details: '', testable: true, icon: <StorageIcon /> },
+  { id: 'dynamodb', name: 'DynamoDB Database', status: 'Unknown', details: '', testable: true, icon: <DnsIcon /> },
+];
+
+const DiagnosticsPage = () => {
+  const [services, setServices] = useState(initialServices);
+
+  const handleTestService = async (serviceId) => {
+    setServices(prev => prev.map(s => s.id === serviceId ? { ...s, status: 'Checking...', details: '' } : s));
+
+    try {
+      const response = serviceId === 's3'
+        ? await adminService.checkS3Connectivity()
+        : await adminService.checkDynamoDBConnectivity();
+
+      if (response && response.success) {
+        setServices(prev => prev.map(s => s.id === serviceId ? { ...s, status: 'Online', details: response.message } : s));
+        // Update API Gateway & Lambdas if this test was successful
+        setServices(prev => prev.map(s => {
+          if ((s.id === 'apiGateway' || s.id === 'lambdas') && s.status !== 'Error') {
+            return { ...s, status: 'Online', details: `Connectivity implied by successful ${serviceId.toUpperCase()} test.` };
+          }
+          return s;
+        }));
+      } else {
+        throw new Error(response?.message || 'Test failed with no specific message.');
+      }
+    } catch (error) {
+      setServices(prev => prev.map(s => s.id === serviceId ? { ...s, status: 'Error', details: error.message || 'An unknown error occurred' } : s));
+      // Optionally mark API Gateway/Lambdas as potentially degraded if a specific test fails
+      setServices(prev => prev.map(s => {
+        if ((s.id === 'apiGateway' || s.id === 'lambdas') && s.status !== 'Error') {
+          return { ...s, status: 'Potentially Degraded', details: `A ${serviceId.toUpperCase()} test failed.` };
+        }
+        return s;
+      }));
+    }
+  };
+
+  const getStatusProps = (status) => {
+    switch (status) {
+      case 'Online':
+        return { color: 'success', icon: <CheckCircleOutlineIcon /> };
+      case 'Error':
+        return { color: 'error', icon: <ErrorOutlineIcon /> };
+      case 'Checking...':
+        return { color: 'warning', icon: <HourglassEmptyIcon /> };
+      case 'Potentially Degraded':
+        return { color: 'info', icon: <HelpOutlineIcon /> }; // Or a more specific warning icon
+      case 'Unknown':
+      default:
+        return { color: 'default', icon: <HelpOutlineIcon /> };
+    }
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        System Diagnostics
+      </Typography>
+      <List>
+        {services.map((service) => {
+          const statusProps = getStatusProps(service.status);
+          return (
+            <React.Fragment key={service.id}>
+              <ListItem>
+                <ListItemIcon>{service.icon}</ListItemIcon>
+                <ListItemText primary={service.name} />
+                <Chip
+                  icon={statusProps.icon}
+                  label={service.status}
+                  color={statusProps.color}
+                  sx={{ width: '180px', textAlign: 'left', mr: 2 }} // Adjusted width for longer status text
+                />
+                {service.testable && (
+                  <Button
+                    variant="contained"
+                    onClick={() => handleTestService(service.id)}
+                    disabled={service.status === 'Checking...'}
+                    sx={{ width: '100px' }} // Consistent button width
+                  >
+                    {service.status === 'Checking...' ? <CircularProgress size={24} /> : 'Test'}
+                  </Button>
+                )}
+              </ListItem>
+              {service.details && (
+                <ListItem sx={{ pl: 9, pt: 0, pb: 1 }}> {/* Indent details, adjust padding */}
+                  <ListItemText secondary={service.details} />
+                </ListItem>
+              )}
+              <Divider component="li" />
+            </React.Fragment>
+          );
+        })}
+      </List>
+    </Container>
+  );
+};
+
+export default DiagnosticsPage;

--- a/frontend/src/services/adminService.js
+++ b/frontend/src/services/adminService.js
@@ -427,6 +427,84 @@ export const adminService = {
       console.error(`Error ${enabled ? 'enabling' : 'disabling'} user:`, error);
       throw error;
     }
+  },
+
+  /**
+   * Check S3 connectivity
+   * @returns {Promise<Object>} - S3 connectivity status
+   */
+  async checkS3Connectivity() {
+    try {
+      console.log('Checking S3 connectivity...');
+      const idToken = await getAuthToken();
+      if (!idToken) throw new Error('No authentication token available');
+
+      const response = await fetch(`${import.meta.env.VITE_API_ENDPOINT}/diagnostics/s3`, {
+        method: 'GET',
+        headers: {
+          'Authorization': idToken, // Raw token
+          'Content-Type': 'application/json'
+        }
+      });
+
+      const responseText = await response.text();
+      console.log('S3 Connectivity API response text:', responseText);
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}: ${responseText}`);
+      }
+
+      let data;
+      try {
+        data = JSON.parse(responseText);
+      } catch (parseError) {
+        console.error('Error parsing S3 connectivity response as JSON:', parseError);
+        throw new Error(`Failed to parse response as JSON: ${responseText}`);
+      }
+      return data;
+    } catch (error) {
+      console.error('Error checking S3 connectivity:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Check DynamoDB connectivity
+   * @returns {Promise<Object>} - DynamoDB connectivity status
+   */
+  async checkDynamoDBConnectivity() {
+    try {
+      console.log('Checking DynamoDB connectivity...');
+      const idToken = await getAuthToken();
+      if (!idToken) throw new Error('No authentication token available');
+
+      const response = await fetch(`${import.meta.env.VITE_API_ENDPOINT}/diagnostics/dynamodb`, {
+        method: 'GET',
+        headers: {
+          'Authorization': idToken, // Raw token
+          'Content-Type': 'application/json'
+        }
+      });
+
+      const responseText = await response.text();
+      console.log('DynamoDB Connectivity API response text:', responseText);
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}: ${responseText}`);
+      }
+
+      let data;
+      try {
+        data = JSON.parse(responseText);
+      } catch (parseError) {
+        console.error('Error parsing DynamoDB connectivity response as JSON:', parseError);
+        throw new Error(`Failed to parse response as JSON: ${responseText}`);
+      }
+      return data;
+    } catch (error) {
+      console.error('Error checking DynamoDB connectivity:', error);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
Adds a system diagnostics feature accessible via a new Admin Settings page.

Key changes:
- I created a new Admin Settings page (`/admin/settings`) to house administrative configurations.
- I integrated a System Diagnostics section into the Admin Settings page.
- The Diagnostics section allows admins to test and view the connectivity status of:
    - S3 Storage
    - DynamoDB Database
- I added backend Lambda functions to perform these connectivity checks.
- I configured API Gateway endpoints for these new Lambda functions.
- I updated frontend services and UI components to call these endpoints and display results.
- I added a "Settings" link to the admin sidebar, positioned at the bottom, providing access to the new settings page.